### PR TITLE
Disable connection on init, add contextmanager for on-the-fly connection

### DIFF
--- a/bluepy_devices/devices/eq3btsmart.py
+++ b/bluepy_devices/devices/eq3btsmart.py
@@ -83,10 +83,6 @@ class EQ3BTSmartThermostat:
         self._conn = BTLEConnection(_mac)
         self._conn.set_callback(PROP_NTFY_HANDLE, self.handle_notification)
 
-        self._conn.connect()
-
-        self.update()
-
     def __str__(self):
         if self.mode == EQ3BTSMART_AWAY:
             away_end = " away end: " + str(self._away_end)
@@ -138,6 +134,9 @@ class EQ3BTSmartThermostat:
             _LOGGER.debug("Mode:        %s", self.mode_readable)
             _LOGGER.debug("Target temp: %s", self._target_temperature)
             _LOGGER.debug("Away end:    %s", self._away_end)
+
+        else:
+            _LOGGER.debug("Unknown notification %s (%s)", (data[0], data))
 
     def update(self):
         """Update the data from the thermostat. Always sets the current time."""

--- a/utils/eq3cli.py
+++ b/utils/eq3cli.py
@@ -14,7 +14,10 @@ def cli(ctx, mac, debug):
     else:
         logging.basicConfig(level=logging.INFO)
 
-    ctx.obj = EQ3BTSmartThermostat(mac)
+    thermostat = EQ3BTSmartThermostat(mac)
+    thermostat.update()
+    ctx.obj = thermostat
+
     if ctx.invoked_subcommand is None:
         ctx.invoke(state)
 


### PR DESCRIPTION
These two commits make it unnecessary to connect during the initialization of the plug, letting homeassistant to add the device even if it's temporarily not connectable.

I'll soon create a request to pull the counterpart to allow homeassistant not to keep the connection alive forever but only connect when needed, thus allowing the ability to use other means for communication without shutting down HA.